### PR TITLE
Fix helm deployment

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -221,7 +221,7 @@ jobs:
   helm-deploy:
     needs: [detect-changes, docker-release-genai, docker-release-server, docker-release-client]
     if: |
-      github.ref == 'refs/heads/main'
+      always() && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code


### PR DESCRIPTION
I would suggest to add an `always()` condition to the helm deployment for now to ensure that helm deployment will always run regardless of anything. 
If one of the docker releases fails, we can detect the failure and run the pipeline again manually if needed. 