### PR TITLE
Add cloud llm model support

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,13 +1,13 @@
 services:
-#  server-service:
-#    build:
-#      context: ./server
-#    container_name: server
-#    ports:
-#      - "8080:8080"
-#    restart: unless-stopped
-#    env_file:
-#      - ./server/.env
+  server-service:
+    build:
+      context: ./server
+    container_name: server
+    ports:
+      - "8080:8080"
+    restart: unless-stopped
+    env_file:
+      - ./server/.env
 
   genai-service:
     build:
@@ -16,7 +16,7 @@ services:
     ports:
       - "8000:8000"
     depends_on:
-#      - server-service
+      - server-service
       - qdrant-service
     restart: unless-stopped
     env_file:
@@ -32,120 +32,120 @@ services:
     volumes:
       - qdrant_storage:/qdrant/storage
 
-#  client-service:
-#    build:
-#      context: ./client
-#      args:
-#        - NODE_ENV=development
-#    container_name: client
-#    ports:
-#      - "5173:80"
-#    depends_on:
-#      - server-service
-#    restart: unless-stopped
-#
-#  mongodb:
-#    image: mongo:8.0
-#    container_name: mongodb
-#    ports:
-#      - "27017:27017"
-#    environment:
-#      - MONGO_INITDB_ROOT_USERNAME=admin
-#      - MONGO_INITDB_ROOT_PASSWORD=admin
-#      - MONGO_INITDB_DATABASE=recipai
-#    volumes:
-#      - mongodb_data:/data/db
-#    restart: unless-stopped
-#
-#  mongo-express:
-#    image: mongo-express:latest
-#    container_name: mongo-express
-#    ports:
-#      - "8081:8081"
-#    environment:
-#      - ME_CONFIG_MONGODB_ADMINUSERNAME=admin
-#      - ME_CONFIG_MONGODB_ADMINPASSWORD=admin
-#      - ME_CONFIG_MONGODB_SERVER=mongodb
-#      - ME_CONFIG_MONGODB_PORT=27017
-#      - ME_CONFIG_BASICAUTH_USERNAME=admin
-#      - ME_CONFIG_BASICAUTH_PASSWORD=admin
-#    depends_on:
-#      - mongodb
-#    restart: unless-stopped
-#
-#  prometheus:
-#    image: prom/prometheus:v2.52.0
-#    container_name: prometheus
-#    ports:
-#      - "9090:9090"
-#    volumes:
-#      - ./monitoring/prometheus:/etc/prometheus
-#      - prometheus_data:/prometheus
-#    command:
-#      - '--config.file=/etc/prometheus/prometheus.yml'
-#      - '--storage.tsdb.path=/prometheus'
-#      - '--web.console.libraries=/etc/prometheus/console_libraries'
-#      - '--web.console.templates=/etc/prometheus/consoles'
-#      - '--web.enable-lifecycle'
-#    restart: unless-stopped
-#
-#  grafana:
-#    image: grafana/grafana-oss:latest
-#    container_name: grafana
-#    ports:
-#      - "3001:3000"
-#    volumes:
-#      - grafana-storage:/var/lib/grafana
-#      - ./monitoring/grafana/provisioning:/etc/grafana/provisioning:ro
-#    environment:
-#      - GF_SECURITY_ADMIN_USER=admin
-#      - GF_SECURITY_ADMIN_PASSWORD=admin
-#      - GF_USERS_ALLOW_SIGN_UP=false
-#      - GF_FEATURE_TOGGLES_ENABLE=logsInExplore
-#      - GF_LOG_CONSOLECOLORS=true
-#    depends_on:
-#      - prometheus
-#      - loki
-#    restart: unless-stopped
-#
-#  promtail:
-#    image: grafana/promtail:latest
-#    volumes:
-#      - /var/lib/docker/containers:/var/lib/docker/containers:ro
-#      - /var/run/docker.sock:/var/run/docker.sock
-#      - ./monitoring/promtail/promtail.yaml:/etc/promtail/promtail.yaml
-#    command: -config.file=/etc/promtail/promtail.yaml
-#    depends_on:
-#      - loki
-#    restart: unless-stopped
-#
-#  loki:
-#    image: grafana/loki:2.9.0
-#    ports:
-#      - "3100:3100"
-#    volumes:
-#      - ./monitoring/loki/loki-config.yaml:/etc/loki/loki-config.yaml:ro
-#      - loki-data:/loki
-#    command: -config.file=/etc/loki/loki-config.yaml
-#    restart: unless-stopped
-#
-#  cadvisor:
-#    image: gcr.io/cadvisor/cadvisor:latest
-#    container_name: cadvisor
-#    ports:
-#      - "8003:8080"
-#    volumes:
-#      - /:/rootfs:ro
-#      - /var/run:/var/run:ro
-#      - /sys:/sys:ro
-#      - /var/lib/docker/:/var/lib/docker:ro
-#      - /dev/disk/:/dev/disk:ro
-#    privileged: true
-#    restart: unless-stopped
+  client-service:
+    build:
+      context: ./client
+      args:
+        - NODE_ENV=development
+    container_name: client
+    ports:
+      - "5173:80"
+    depends_on:
+      - server-service
+    restart: unless-stopped
+
+  mongodb:
+    image: mongo:8.0
+    container_name: mongodb
+    ports:
+      - "27017:27017"
+    environment:
+      - MONGO_INITDB_ROOT_USERNAME=admin
+      - MONGO_INITDB_ROOT_PASSWORD=admin
+      - MONGO_INITDB_DATABASE=recipai
+    volumes:
+      - mongodb_data:/data/db
+    restart: unless-stopped
+
+  mongo-express:
+    image: mongo-express:latest
+    container_name: mongo-express
+    ports:
+      - "8081:8081"
+    environment:
+      - ME_CONFIG_MONGODB_ADMINUSERNAME=admin
+      - ME_CONFIG_MONGODB_ADMINPASSWORD=admin
+      - ME_CONFIG_MONGODB_SERVER=mongodb
+      - ME_CONFIG_MONGODB_PORT=27017
+      - ME_CONFIG_BASICAUTH_USERNAME=admin
+      - ME_CONFIG_BASICAUTH_PASSWORD=admin
+    depends_on:
+      - mongodb
+    restart: unless-stopped
+
+  prometheus:
+    image: prom/prometheus:v2.52.0
+    container_name: prometheus
+    ports:
+      - "9090:9090"
+    volumes:
+      - ./monitoring/prometheus:/etc/prometheus
+      - prometheus_data:/prometheus
+    command:
+      - '--config.file=/etc/prometheus/prometheus.yml'
+      - '--storage.tsdb.path=/prometheus'
+      - '--web.console.libraries=/etc/prometheus/console_libraries'
+      - '--web.console.templates=/etc/prometheus/consoles'
+      - '--web.enable-lifecycle'
+    restart: unless-stopped
+
+  grafana:
+    image: grafana/grafana-oss:latest
+    container_name: grafana
+    ports:
+      - "3001:3000"
+    volumes:
+      - grafana-storage:/var/lib/grafana
+      - ./monitoring/grafana/provisioning:/etc/grafana/provisioning:ro
+    environment:
+      - GF_SECURITY_ADMIN_USER=admin
+      - GF_SECURITY_ADMIN_PASSWORD=admin
+      - GF_USERS_ALLOW_SIGN_UP=false
+      - GF_FEATURE_TOGGLES_ENABLE=logsInExplore
+      - GF_LOG_CONSOLECOLORS=true
+    depends_on:
+      - prometheus
+      - loki
+    restart: unless-stopped
+
+  promtail:
+    image: grafana/promtail:latest
+    volumes:
+      - /var/lib/docker/containers:/var/lib/docker/containers:ro
+      - /var/run/docker.sock:/var/run/docker.sock
+      - ./monitoring/promtail/promtail.yaml:/etc/promtail/promtail.yaml
+    command: -config.file=/etc/promtail/promtail.yaml
+    depends_on:
+      - loki
+    restart: unless-stopped
+
+  loki:
+    image: grafana/loki:2.9.0
+    ports:
+      - "3100:3100"
+    volumes:
+      - ./monitoring/loki/loki-config.yaml:/etc/loki/loki-config.yaml:ro
+      - loki-data:/loki
+    command: -config.file=/etc/loki/loki-config.yaml
+    restart: unless-stopped
+
+  cadvisor:
+    image: gcr.io/cadvisor/cadvisor:latest
+    container_name: cadvisor
+    ports:
+      - "8003:8080"
+    volumes:
+      - /:/rootfs:ro
+      - /var/run:/var/run:ro
+      - /sys:/sys:ro
+      - /var/lib/docker/:/var/lib/docker:ro
+      - /dev/disk/:/dev/disk:ro
+    privileged: true
+    restart: unless-stopped
 
 volumes:
   qdrant_storage:
-#  mongodb_data:
-#  prometheus_data:
-#  grafana-storage:
-#  loki-data:
+  mongodb_data:
+  prometheus_data:
+  grafana-storage:
+  loki-data:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,13 +1,13 @@
 services:
-  server-service:
-    build:
-      context: ./server
-    container_name: server
-    ports:
-      - "8080:8080"
-    restart: unless-stopped
-    env_file:
-      - ./server/.env
+#  server-service:
+#    build:
+#      context: ./server
+#    container_name: server
+#    ports:
+#      - "8080:8080"
+#    restart: unless-stopped
+#    env_file:
+#      - ./server/.env
 
   genai-service:
     build:
@@ -16,7 +16,7 @@ services:
     ports:
       - "8000:8000"
     depends_on:
-      - server-service
+#      - server-service
       - qdrant-service
     restart: unless-stopped
     env_file:
@@ -32,120 +32,120 @@ services:
     volumes:
       - qdrant_storage:/qdrant/storage
 
-  client-service:
-    build:
-      context: ./client
-      args:
-        - NODE_ENV=development
-    container_name: client
-    ports:
-      - "5173:80"
-    depends_on:
-      - server-service
-    restart: unless-stopped
-
-  mongodb:
-    image: mongo:8.0
-    container_name: mongodb
-    ports:
-      - "27017:27017"
-    environment:
-      - MONGO_INITDB_ROOT_USERNAME=admin
-      - MONGO_INITDB_ROOT_PASSWORD=admin
-      - MONGO_INITDB_DATABASE=recipai
-    volumes:
-      - mongodb_data:/data/db
-    restart: unless-stopped
-
-  mongo-express:
-    image: mongo-express:latest
-    container_name: mongo-express
-    ports:
-      - "8081:8081"
-    environment:
-      - ME_CONFIG_MONGODB_ADMINUSERNAME=admin
-      - ME_CONFIG_MONGODB_ADMINPASSWORD=admin
-      - ME_CONFIG_MONGODB_SERVER=mongodb
-      - ME_CONFIG_MONGODB_PORT=27017
-      - ME_CONFIG_BASICAUTH_USERNAME=admin
-      - ME_CONFIG_BASICAUTH_PASSWORD=admin
-    depends_on:
-      - mongodb
-    restart: unless-stopped
-
-  prometheus: 
-    image: prom/prometheus:v2.52.0
-    container_name: prometheus
-    ports: 
-      - "9090:9090"
-    volumes:
-      - ./monitoring/prometheus:/etc/prometheus
-      - prometheus_data:/prometheus
-    command:
-      - '--config.file=/etc/prometheus/prometheus.yml'
-      - '--storage.tsdb.path=/prometheus'
-      - '--web.console.libraries=/etc/prometheus/console_libraries'
-      - '--web.console.templates=/etc/prometheus/consoles'
-      - '--web.enable-lifecycle'
-    restart: unless-stopped
-
-  grafana:
-    image: grafana/grafana-oss:latest
-    container_name: grafana
-    ports:
-      - "3001:3000"
-    volumes:
-      - grafana-storage:/var/lib/grafana
-      - ./monitoring/grafana/provisioning:/etc/grafana/provisioning:ro
-    environment:
-      - GF_SECURITY_ADMIN_USER=admin
-      - GF_SECURITY_ADMIN_PASSWORD=admin
-      - GF_USERS_ALLOW_SIGN_UP=false
-      - GF_FEATURE_TOGGLES_ENABLE=logsInExplore
-      - GF_LOG_CONSOLECOLORS=true
-    depends_on:
-      - prometheus
-      - loki
-    restart: unless-stopped
-
-  promtail:
-    image: grafana/promtail:latest
-    volumes:
-      - /var/lib/docker/containers:/var/lib/docker/containers:ro
-      - /var/run/docker.sock:/var/run/docker.sock
-      - ./monitoring/promtail/promtail.yaml:/etc/promtail/promtail.yaml
-    command: -config.file=/etc/promtail/promtail.yaml
-    depends_on:
-      - loki
-    restart: unless-stopped
-
-  loki:
-    image: grafana/loki:2.9.0
-    ports:
-      - "3100:3100"
-    volumes:
-      - ./monitoring/loki/loki-config.yaml:/etc/loki/loki-config.yaml:ro
-      - loki-data:/loki
-    command: -config.file=/etc/loki/loki-config.yaml
-    restart: unless-stopped
-  
-  cadvisor:
-    image: gcr.io/cadvisor/cadvisor:latest
-    container_name: cadvisor
-    ports:
-      - "8003:8080"
-    volumes:
-      - /:/rootfs:ro
-      - /var/run:/var/run:ro
-      - /sys:/sys:ro
-      - /var/lib/docker/:/var/lib/docker:ro
-      - /dev/disk/:/dev/disk:ro
-    privileged: true
-    restart: unless-stopped
+#  client-service:
+#    build:
+#      context: ./client
+#      args:
+#        - NODE_ENV=development
+#    container_name: client
+#    ports:
+#      - "5173:80"
+#    depends_on:
+#      - server-service
+#    restart: unless-stopped
+#
+#  mongodb:
+#    image: mongo:8.0
+#    container_name: mongodb
+#    ports:
+#      - "27017:27017"
+#    environment:
+#      - MONGO_INITDB_ROOT_USERNAME=admin
+#      - MONGO_INITDB_ROOT_PASSWORD=admin
+#      - MONGO_INITDB_DATABASE=recipai
+#    volumes:
+#      - mongodb_data:/data/db
+#    restart: unless-stopped
+#
+#  mongo-express:
+#    image: mongo-express:latest
+#    container_name: mongo-express
+#    ports:
+#      - "8081:8081"
+#    environment:
+#      - ME_CONFIG_MONGODB_ADMINUSERNAME=admin
+#      - ME_CONFIG_MONGODB_ADMINPASSWORD=admin
+#      - ME_CONFIG_MONGODB_SERVER=mongodb
+#      - ME_CONFIG_MONGODB_PORT=27017
+#      - ME_CONFIG_BASICAUTH_USERNAME=admin
+#      - ME_CONFIG_BASICAUTH_PASSWORD=admin
+#    depends_on:
+#      - mongodb
+#    restart: unless-stopped
+#
+#  prometheus:
+#    image: prom/prometheus:v2.52.0
+#    container_name: prometheus
+#    ports:
+#      - "9090:9090"
+#    volumes:
+#      - ./monitoring/prometheus:/etc/prometheus
+#      - prometheus_data:/prometheus
+#    command:
+#      - '--config.file=/etc/prometheus/prometheus.yml'
+#      - '--storage.tsdb.path=/prometheus'
+#      - '--web.console.libraries=/etc/prometheus/console_libraries'
+#      - '--web.console.templates=/etc/prometheus/consoles'
+#      - '--web.enable-lifecycle'
+#    restart: unless-stopped
+#
+#  grafana:
+#    image: grafana/grafana-oss:latest
+#    container_name: grafana
+#    ports:
+#      - "3001:3000"
+#    volumes:
+#      - grafana-storage:/var/lib/grafana
+#      - ./monitoring/grafana/provisioning:/etc/grafana/provisioning:ro
+#    environment:
+#      - GF_SECURITY_ADMIN_USER=admin
+#      - GF_SECURITY_ADMIN_PASSWORD=admin
+#      - GF_USERS_ALLOW_SIGN_UP=false
+#      - GF_FEATURE_TOGGLES_ENABLE=logsInExplore
+#      - GF_LOG_CONSOLECOLORS=true
+#    depends_on:
+#      - prometheus
+#      - loki
+#    restart: unless-stopped
+#
+#  promtail:
+#    image: grafana/promtail:latest
+#    volumes:
+#      - /var/lib/docker/containers:/var/lib/docker/containers:ro
+#      - /var/run/docker.sock:/var/run/docker.sock
+#      - ./monitoring/promtail/promtail.yaml:/etc/promtail/promtail.yaml
+#    command: -config.file=/etc/promtail/promtail.yaml
+#    depends_on:
+#      - loki
+#    restart: unless-stopped
+#
+#  loki:
+#    image: grafana/loki:2.9.0
+#    ports:
+#      - "3100:3100"
+#    volumes:
+#      - ./monitoring/loki/loki-config.yaml:/etc/loki/loki-config.yaml:ro
+#      - loki-data:/loki
+#    command: -config.file=/etc/loki/loki-config.yaml
+#    restart: unless-stopped
+#
+#  cadvisor:
+#    image: gcr.io/cadvisor/cadvisor:latest
+#    container_name: cadvisor
+#    ports:
+#      - "8003:8080"
+#    volumes:
+#      - /:/rootfs:ro
+#      - /var/run:/var/run:ro
+#      - /sys:/sys:ro
+#      - /var/lib/docker/:/var/lib/docker:ro
+#      - /dev/disk/:/dev/disk:ro
+#    privileged: true
+#    restart: unless-stopped
 
 volumes:
   qdrant_storage:
-  mongodb_data:
-  prometheus_data:
-  grafana-storage:
-  loki-data:
+#  mongodb_data:
+#  prometheus_data:
+#  grafana-storage:
+#  loki-data:

--- a/genai/.env.template
+++ b/genai/.env.template
@@ -1,3 +1,9 @@
+# Cloud based LLM models
 API_OPENAI="your openai key"
+API_ANTHROPIC="your anthropic key"
+API_MISTRAL="your mistral key"
+API_HUGGINGFACEHUB="your huggingface api token"
+# Local Models
 API_OPENWEBUI="your openwebui key"
+# Base URL for calling local models
 BASE_URL="https://gpu.aet.cit.tum.de"

--- a/genai/config.py
+++ b/genai/config.py
@@ -9,13 +9,19 @@ ConfigT = namedtuple(
     "Config",
     [
         "api_key_openai",
-        "api_openwebui",
+        "api_key_anthropic",
+        "api_key_mistral",
+        "api_key_huggingface",
+        "api_key_openwebui",
         "base_url"
     ],
 )
 
 Config = ConfigT(
     api_key_openai=environ.get("API_OPENAI"),
-    api_openwebui=environ.get("API_OPENWEBUI"),
+    api_key_anthropic=environ.get("API_ANTHROPIC", ""),
+    api_key_mistral=environ.get("API_MISTRAL", ""),
+    api_key_huggingface=environ.get("API_HUGGINGFACE", ""),
+    api_key_openwebui=environ.get("API_OPENWEBUI"),
     base_url=environ.get("BASE_URL")
 )

--- a/genai/rag/llm/cloud_chat_model.py
+++ b/genai/rag/llm/cloud_chat_model.py
@@ -1,0 +1,52 @@
+import os
+
+from langchain.chat_models import init_chat_model
+from langchain_core.prompt_values import PromptValue
+from langchain_core.messages import BaseMessage
+
+from config import Config
+
+
+class CloudLLM:
+    """A concrete implementation of a cloud-based LLM. Uses openai as the default LLM provider."""
+
+    def __init__(self, model_name: str = "gpt-4-1106-preview", model_provider: str = "openai", api_key: str = Config.api_key_openai):
+        provider = model_provider.lower()
+        if provider == "openai":
+            os.environ["OPENAI_API_KEY"] = api_key or os.getenv("API_OPENAI", "")
+        elif provider == "anthropic":
+            os.environ["ANTHROPIC_API_KEY"] = api_key or os.getenv("API_ANTHROPIC", "")
+        elif provider == "mistral":
+            os.environ["MISTRAL_API_KEY"] = api_key or os.getenv("API_MISTRAL", "")
+        elif provider == "huggingface":
+            os.environ["HUGGINGFACEHUB_API_TOKEN"] = api_key or os.getenv("API_HUGGINGFACEHUB", "")
+        else:
+            raise ValueError(f"Unsupported LLM provider: {provider}")
+
+        self.model = init_chat_model(model=model_name, model_provider=provider)
+
+    def get_system_prompt(self) -> str:
+        """System prompt for the LLM"""
+        return """
+            You are an intelligent assistant that helps users discover
+            and generate recipes based on the ingredients they provide.
+
+            Use the contextual information provided below to tailor
+            your responses.
+
+            If relevant recipes or suggestions are found in the context,
+            prioritize those. If no relevant context is available,
+            use your own knowledge to help the user.
+
+            Context:
+            {context}
+
+            Be clear, creative, and helpful. If the user also asks
+            follow-up questions (e.g., dietary adjustments, name references,
+            meal timing), answer them precisely based on the
+            context and query.
+            """
+    def invoke(self, prompt: PromptValue) -> BaseMessage:
+        """Invoke the LLM with the given prompt"""
+        return self.model.invoke(prompt)
+

--- a/genai/routes/routes.py
+++ b/genai/routes/routes.py
@@ -1,12 +1,15 @@
 from fastapi import APIRouter, UploadFile, File, HTTPException, Request
 from fastapi.responses import JSONResponse
 import os
+
+# from config import Config
 from logger import logger
 from time import perf_counter
 
 from vector_database.qdrant_vdb import QdrantVDB
 from rag.ingestion_pipeline import IngestionPipeline
 from rag.llm.chat_model import ChatModel
+# from rag.llm.cloud_chat_model import CloudLLM
 from service.rag_service import (
     retrieve_similar_docs,
     prepare_prompt,
@@ -26,8 +29,43 @@ from metrics import (
 
 router = APIRouter()
 
-llm = ChatModel(model_name="llama3.3:latest")
+# Set vector database
 qdrant = QdrantVDB()
+
+# Set chat model for local llm models
+# Make calls to local models in openwebui hosted by the university
+llm = ChatModel(model_name="llama3.3:latest")
+
+# Alternatively, we can switch to a chat model based on cloud models as well
+# If you want to use other cloud models, please adjust model_name,
+# model_provider, and api key
+# accordingly
+
+# Examples:
+# llm_cloud_anthropic = CloudLLM(
+#     model_name="claude-3-sonnet-20240229",
+#     model_provider="anthropic",
+#     api_key=Config.api_key_anthropic,
+# )
+# llm_cloud_openai = CloudLLM(
+#     model_name="gpt-4-1106-preview",
+#     model_provider="openai",
+#     api_key=Config.api_key_openai,
+# )
+#
+# llm_cloud_mistral = CloudLLM(
+#     model_name="mistral-medium",
+#     model_provider="mistral",
+#     api_key=Config.api_key_mistral,
+# )
+
+# If no parameters are provided, the default cloud model will be openai.
+# If a cloud model is wanted, please remove the comment
+# for package import "CloudLLM"
+
+# Example:
+#llm = CloudLLM() # same as llm_cloud_openai
+
 
 
 @router.post("/upload")
@@ -130,6 +168,7 @@ async def generate(request: Request):
 
         response = llm.invoke(prompt)
         logger.info("Response is generated")
+
         generation_successfully_counter.inc()
 
         return JSONResponse(content={"response": response.content})

--- a/genai/service/openwebui_service.py
+++ b/genai/service/openwebui_service.py
@@ -12,7 +12,7 @@ def generate_response(model_name: str, prompt: str):
     url = f"{BASE_URL}/api/chat/completions"
 
     headers = {
-        "Authorization": f"Bearer {Config.api_openwebui}",
+        "Authorization": f"Bearer {Config.api_key_openwebui}",
         "Content-Type": "application/json"
     }
 

--- a/genai/service/rag_service.py
+++ b/genai/service/rag_service.py
@@ -3,7 +3,6 @@ from typing import List, Dict
 from langchain_qdrant import QdrantVectorStore
 from langchain_core.messages import BaseMessage, HumanMessage, AIMessage
 from langchain_core.prompts import ChatPromptTemplate, MessagesPlaceholder
-# from genai.rag.llm.chat_model import ChatModel
 
 
 def retrieve_similar_docs(vector_store: QdrantVectorStore, user_query: str):
@@ -49,13 +48,3 @@ def process_raw_messages(raw_messages: List[Dict]) -> List[BaseMessage]:
 
     return processed_messages
 
-# For testing purposes
-# if __name__ == "__main__":
-#     msg = HumanMessage(content="My name is John Doe.")
-#     llm = ChatModel()
-#     prompt = prepare_prompt(llm.get_system_prompt(),
-#                             "Suggest me a basic breakfast.",
-#                             "",
-#                             [msg])
-#     response = llm.invoke(prompt)
-#     print(response.content)


### PR DESCRIPTION
- Added cloud llm implementation to be able support cloud llm models such as anthropic, openai, mistral, or any cloud models on huggingface
- Integrated cloud llm implementation to be compatible with our route infrastructure, so changing one line would be sufficient to switch the use of local models to cloud models.
- Since our openai key is already integrated in our github secrets and helm deployment, we dont need to create additional secrets for helm. However, if we want to use another cloud model (e.g. Mistral, Anthropic, or Huggingface models), we need to add the corresponding secret configs to helm. 

With this implementation, genai module requirements are almost done :) 